### PR TITLE
Return header from readFile() & other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Returns a Promise. Promise resolves to an Object that contains `blobKey` and `me
 Returns a Promise, resolving to an object that contains:
 
 - `data` (Buffer) The file data
+- `header` (Object) The header for the secure-container
 - `blobKey` (Buffer)
 - `metadata` (Object)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ let write = exports.write = (() => {
       throw new Error('Must set either passphrase or (metadata and blobKey)');
     }
 
-    data = Buffer.isBuffer(data) ? data : new Buffer(data, 'utf8');
+    data = Buffer.isBuffer(data) ? data : Buffer.from(data, 'utf8');
     let { blob: encBlob } = conBlob.encrypt(data, metadata, blobKey);
 
     const headerBuf = conHeader.serialize(header);

--- a/lib/index.js
+++ b/lib/index.js
@@ -80,9 +80,10 @@ let read = exports.read = (() => {
 
     let metadata = conMetadata.decode(fileObj.metadata);
     let blobKey = conMetadata.decryptBlobKey(metadata, passphrase);
+    let header = conHeader.decode(fileObj.header);
     let data = conBlob.decrypt(fileObj.blob, metadata, blobKey);
 
-    return { data, blobKey, metadata };
+    return { data, blobKey, metadata, header };
   });
 
   return function read(_x3, _x4) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,12 +22,7 @@ let write = exports.write = (() => {
     if (!options.header) console.warn('seco-file: should pass options.header.');
     let header = conHeader.create(options.header);
 
-    let fileExists = yield new Promise(function (resolve) {
-      return _fsExtra2.default.access(file, function (err) {
-        return resolve(!err);
-      });
-    });
-    if (!options.overwrite && fileExists) throw new Error(`${file} exists. Set 'overwrite' to true.`);
+    if (!options.overwrite && (yield _fsExtra2.default.pathExists(file))) throw new Error(`${file} exists. Set 'overwrite' to true.`);
 
     let blobKey;
     let metadata;
@@ -56,11 +51,7 @@ let write = exports.write = (() => {
     };
     const fileData = conFile.encode(fileObj);
 
-    yield new Promise(function (resolve, reject) {
-      _fsExtra2.default.outputFile(file, fileData, function (err) {
-        return err ? reject(err) : resolve();
-      });
-    });
+    yield _fsExtra2.default.outputFile(file, fileData);
 
     return { blobKey, metadata };
   });
@@ -80,11 +71,7 @@ let read = exports.read = (() => {
       throw new TypeError('Value of argument "passphrase" violates contract.\n\nExpected:\nBufOrStr\n\nGot:\n' + _inspect(passphrase));
     }
 
-    let fileData = yield new Promise(function (resolve, reject) {
-      _fsExtra2.default.readFile(file, function (err, fileData) {
-        return err ? reject(err) : resolve(fileData);
-      });
-    });
+    let fileData = yield _fsExtra2.default.readFile(file);
 
     const fileObj = conFile.decode(fileData);
 

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
   "devDependencies": {
     "aw": "^0.1.0",
     "babel-cli": "^6.9.0",
-    "babel-eslint": "^6.0.4",
+    "babel-eslint": "^7.2.3",
     "babel-plugin-syntax-flow": "^6.8.0",
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-plugin-typecheck": "^3.9.0",
     "babel-preset-node6": "^11.0.0",
     "babel-preset-stage-2": "^6.5.0",
     "babel-register": "^6.9.0",
-    "standard": "^7.1.0",
+    "standard": "^10.0.2",
     "tap-spec": "^4.1.1",
     "tape": "^4.5.1",
     "tape-promise": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "standard": "^10.0.2",
     "tap-spec": "^4.1.1",
     "tape": "^4.5.1",
-    "tape-promise": "^1.1.0"
+    "tape-promise": "^2.0.1"
   },
   "engines": {
     "node": ">= 6.0.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "secure-container": "0.0.2",
-    "fs-extra": "^0.30.0"
+    "fs-extra": "^3.0.1"
   },
   "devDependencies": {
     "aw": "^0.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -14,8 +14,7 @@ export async function write (file: string, data: BufOrStr, options = {}) {
   if (!options.header) console.warn('seco-file: should pass options.header.')
   let header = conHeader.create(options.header)
 
-  let fileExists = await new Promise(resolve => fs.access(file, err => resolve(!err)))
-  if (!options.overwrite && fileExists) throw new Error(`${file} exists. Set 'overwrite' to true.`)
+  if (!options.overwrite && await fs.pathExists(file)) throw new Error(`${file} exists. Set 'overwrite' to true.`)
 
   let blobKey
   let metadata
@@ -44,17 +43,13 @@ export async function write (file: string, data: BufOrStr, options = {}) {
   }
   const fileData = conFile.encode(fileObj)
 
-  await new Promise((resolve, reject) => {
-    fs.outputFile(file, fileData, err => err ? reject(err) : resolve())
-  })
+  await fs.outputFile(file, fileData)
 
   return { blobKey, metadata }
 }
 
 export async function read (file: string, passphrase: BufOrStr) {
-  let fileData = await new Promise((resolve, reject) => {
-    fs.readFile(file, (err, fileData) => err ? reject(err) : resolve(fileData))
-  })
+  let fileData = await fs.readFile(file)
 
   const fileObj = conFile.decode(fileData)
 

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,8 @@ export async function read (file: string, passphrase: BufOrStr) {
 
   let metadata = conMetadata.decode(fileObj.metadata)
   let blobKey = conMetadata.decryptBlobKey(metadata, passphrase)
+  let header = conHeader.decode(fileObj.header)
   let data = conBlob.decrypt(fileObj.blob, metadata, blobKey)
 
-  return { data, blobKey, metadata }
+  return { data, blobKey, metadata, header }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ export async function write (file: string, data: BufOrStr, options = {}) {
     throw new Error('Must set either passphrase or (metadata and blobKey)')
   }
 
-  data = Buffer.isBuffer(data) ? data : new Buffer(data, 'utf8')
+  data = Buffer.isBuffer(data) ? data : Buffer.from(data, 'utf8')
   let { blob: encBlob } = conBlob.encrypt(data, metadata, blobKey)
 
   const headerBuf = conHeader.serialize(header)

--- a/tests/read-file.test.js
+++ b/tests/read-file.test.js
@@ -36,3 +36,27 @@ test('readFile verifies checksum', async (t) => {
   t.ok(err.message.match(/seco checksum does not match; file may be corrupted/))
   t.end()
 })
+
+test('readFile returns header', async (t) => {
+  const testDir = path.join('/tmp', 'test', 'seco-file')
+  const testFile = path.join(testDir, 'secret.bin')
+  fs.emptyDirSync(testDir)
+
+  let secretMessage = Buffer.from('Hi, lets meet at 10 PM to plan our secret mission!', 'utf8')
+  const passphrase = Buffer.from('opensesame')
+  const header = {
+    appName: 'test',
+    appVersion: '1.0.0'
+  }
+
+  const [writeFileErr] = await aw(writeFile)(testFile, secretMessage, { passphrase, overwrite: true, header })
+  t.ifError(writeFileErr, 'no error')
+
+  const [readFileErr, readFileRes] = await aw(readFile)(testFile, passphrase)
+  t.ifError(readFileErr, 'no error on read')
+
+  t.is(readFileRes.header.appName, header.appName, 'appName is returned')
+  t.is(readFileRes.header.appVersion, header.appVersion, 'appVersion is returned')
+
+  t.end()
+})


### PR DESCRIPTION
@jprichardson Sorry for the big PR; it just seemed the fastest to get this all done at once vs. waiting for your review at each step.

- Removed `new Buffer` usage
- Updated deps & devDeps (fs-extra was stuck on v0.30!)
- Modified `readFile` to return the header, as discussed on the phone