### PR TITLE
Write to tmpfile first to avoid corruption

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,9 @@ export async function write (file: string, data: BufOrStr, options = {}) {
 
   const { encryptedData, blobKey, metadata } = encryptData(data, options)
 
-  await fs.outputFile(file, encryptedData)
+  const tmpFile = file + '.tmp'
+  await fs.outputFile(tmpFile, encryptedData)
+  await fs.rename(tmpFile, file)
 
   return { blobKey, metadata }
 }


### PR DESCRIPTION
We have a theory that there is a possibility of info.seco being corrupted (for example when the app freezes when exiting). The theory is that as our info.seco files grow in size the time window the process can exit or freeze and cause corruption when writing gets longer and longer. This is just an attempt to mitigate that
